### PR TITLE
Bookmarked test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4539,7 +4539,6 @@
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.5.0.tgz",
       "integrity": "sha512-xGGHpBXYSHUUr6XsKBfs85TWlYKpTc37cSBBVrXcib2MkHLboWlkClhWF37JKlDb9KEq3dHs+f2xR7XJEWGBxA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@adobe/css-tools": "^4.4.0",
         "aria-query": "^5.0.0",
@@ -4640,7 +4639,6 @@
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.0.1.tgz",
       "integrity": "sha512-dSmwJVtJXmku+iocRhWOUFbrERC76TX2Mnf0ATODz8brzAZrMBbzLwQixlBSanZxR6LddK3eiwpSFZgDET1URg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5"
       },

--- a/src/tests/BookMarkedTest.test.tsx
+++ b/src/tests/BookMarkedTest.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from "@testing-library/react";
+import BookMarkedScreen from "../screens/BookmarkedScreen";
+import { BookmarksProvider } from "../context/BookmarksContext";
+import '@testing-library/jest-dom';  
+
+test("visar meddelande när det inte finns några bokmärkta filmer", () => {
+  render(
+    <BookmarksProvider>
+      <BookMarkedScreen />
+    </BookmarksProvider>
+  );
+  const noBookmarksMessage = screen.getByText(/du har inga bokmärkta filmer/i);
+  expect(noBookmarksMessage).toBeInTheDocument();  
+});
+
+

--- a/src/tests/BookMarkedTest.test.tsx
+++ b/src/tests/BookMarkedTest.test.tsx
@@ -1,16 +1,68 @@
 import { render, screen } from "@testing-library/react";
 import BookMarkedScreen from "../screens/BookmarkedScreen";
-import { BookmarksProvider } from "../context/BookmarksContext";
+import { useBookmarks } from "../context/BookmarksContext"; // mockar denna hook
 import '@testing-library/jest-dom';  
 
+// ersätter useBookmarks-hooken med mockad data
+jest.mock('../context/BookmarksContext', () => ({
+  useBookmarks: jest.fn(),
+}));
+
+// mockar två filmer med bokmärken
+const mockBookmarks = [
+    {
+      title: "Film 1",
+      thumbnail: "thumbnail1.jpg",
+      synopsis: "Synopsis för Film 1",
+      rating: "5",
+      genre: "Drama",
+      year: 2022,
+      actors: ["Skådespelare 1", "Skådespelare 2"],
+    },
+    {
+      title: "Film 2",
+      thumbnail: "thumbnail2.jpg",
+      synopsis: "Synopsis för Film 2",
+      rating: "4",
+      genre: "Action",
+      year: 2021,
+      actors: ["Skådespelare A", "Skådespelare B"],
+    },
+  ];  
+  
+
+// Test 1: Visa meddelande när det inte finns några bokmärkta filmer
 test("visar meddelande när det inte finns några bokmärkta filmer", () => {
-  render(
-    <BookmarksProvider>
-      <BookMarkedScreen />
-    </BookmarksProvider>
-  );
+  // mockar att inga bokmärken finns
+  (useBookmarks as jest.Mock).mockReturnValue({
+    bookmarks: [],
+    addBookmark: jest.fn(),
+    removeBookmark: jest.fn(),
+    isBookmarked: jest.fn(),
+  });
+
+  render(<BookMarkedScreen />);
+
+  // kollar så att meddelandet syns om ej några bokmärken finns
   const noBookmarksMessage = screen.getByText(/du har inga bokmärkta filmer/i);
-  expect(noBookmarksMessage).toBeInTheDocument();  
+  expect(noBookmarksMessage).toBeInTheDocument();
 });
 
+// Test 2: testar de två mockade bokmärkerna
+test("visar bokmärken när de finns", () => {
+  (useBookmarks as jest.Mock).mockReturnValue({
+    bookmarks: mockBookmarks,
+    addBookmark: jest.fn(),
+    removeBookmark: jest.fn(),
+    isBookmarked: jest.fn(),
+  });
 
+  render(<BookMarkedScreen />);
+
+  // kollar att båda fikmerna renderar bokmärke
+  const movie1 = screen.getByText(/film 1/i);
+  const movie2 = screen.getByText(/film 2/i);
+
+  expect(movie1).toBeInTheDocument();
+  expect(movie2).toBeInTheDocument();
+});

--- a/src/tests/BookMarkedTest.test.tsx
+++ b/src/tests/BookMarkedTest.test.tsx
@@ -2,10 +2,10 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import MovieCard from "../components/MovieCard";
 import BookMarkedScreen from "../screens/BookmarkedScreen";
 import { useBookmarks } from "../context/BookmarksContext"; // mockar denna hook
-import '@testing-library/jest-dom';  // För jest-dom matchers
+import "@testing-library/jest-dom"; // För jest-dom matchers
 
 // ersätter useBookmarks-hooken med mockad data från context
-jest.mock('../context/BookmarksContext', () => ({
+jest.mock("../context/BookmarksContext", () => ({
   useBookmarks: jest.fn(),
 }));
 
@@ -78,7 +78,6 @@ test("visar bokmärken när de finns", () => {
   expect(movie2).toBeInTheDocument();
 });
 
-
 // Test 3: testar att lägga till ett bokmärke och uppdatera localStorage
 test("lägger till ett bokmärke och uppdaterar localStorage", () => {
   const mockAddBookmark = jest.fn((movie) => {
@@ -104,7 +103,7 @@ test("lägger till ett bokmärke och uppdaterar localStorage", () => {
   expect(mockIsBookmarked(mockMovie.title)).toBe(false);
 
   // hitta knappen med querySelector
-  const bookmarkButton = container.querySelector('.bookmark-button');
+  const bookmarkButton = container.querySelector(".bookmark-button");
   expect(bookmarkButton).toBeInTheDocument();
 
   fireEvent.click(bookmarkButton!);
@@ -114,7 +113,7 @@ test("lägger till ett bokmärke och uppdaterar localStorage", () => {
   // kollar att localStorage har uppdaterats med den nya filmen
   expect(setItemSpy).toHaveBeenCalledWith(
     "bookmarks",
-    JSON.stringify([mockMovie])
+    JSON.stringify([mockMovie]),
   );
 
   // uppdaterar mock - simulerar att bokmärke lagts till
@@ -125,7 +124,6 @@ test("lägger till ett bokmärke och uppdaterar localStorage", () => {
 
   expect(mockIsBookmarked(mockMovie.title)).toBe(true);
 });
-
 
 // Test 4: testar att ta bort ett bokmärke och uppdatera localStorage
 test("tar bort ett bokmärke och uppdaterar localStorage", () => {
@@ -139,7 +137,7 @@ test("tar bort ett bokmärke och uppdaterar localStorage", () => {
   // mockar localStorage.setItem
   const setItemSpy = jest.spyOn(Storage.prototype, "setItem");
 
-  // mockar useBookmarks 
+  // mockar useBookmarks
   (useBookmarks as jest.Mock).mockReturnValue({
     bookmarks: [mockMovie],
     addBookmark: mockAddBookmark,
@@ -153,7 +151,7 @@ test("tar bort ett bokmärke och uppdaterar localStorage", () => {
   expect(mockIsBookmarked(mockMovie.title)).toBe(true);
 
   // hitta knappen med querySelector
-  const bookmarkButton = container.querySelector('.bookmark-button');
+  const bookmarkButton = container.querySelector(".bookmark-button");
   expect(bookmarkButton).toBeInTheDocument();
 
   fireEvent.click(bookmarkButton!);
@@ -161,12 +159,9 @@ test("tar bort ett bokmärke och uppdaterar localStorage", () => {
   expect(mockRemoveBookmark).toHaveBeenCalledWith(mockMovie.title);
 
   // kollar att localStorage har uppdaterats
-  expect(setItemSpy).toHaveBeenCalledWith(
-    "bookmarks",
-    JSON.stringify([])
-  );
+  expect(setItemSpy).toHaveBeenCalledWith("bookmarks", JSON.stringify([]));
 
-  // uppdaterar mock 
+  // uppdaterar mock
   mockIsBookmarked.mockReturnValue(false);
 
   // renderar om komponenten för att simulera att listan har uppdaterats

--- a/src/tests/BookMarkedTest.test.tsx
+++ b/src/tests/BookMarkedTest.test.tsx
@@ -1,35 +1,46 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import MovieCard from "../components/MovieCard";
 import BookMarkedScreen from "../screens/BookmarkedScreen";
 import { useBookmarks } from "../context/BookmarksContext"; // mockar denna hook
-import '@testing-library/jest-dom';  
+import '@testing-library/jest-dom';  // För jest-dom matchers
 
-// ersätter useBookmarks-hooken med mockad data
+// ersätter useBookmarks-hooken med mockad data från context
 jest.mock('../context/BookmarksContext', () => ({
   useBookmarks: jest.fn(),
 }));
 
 // mockar två filmer med bokmärken
 const mockBookmarks = [
-    {
-      title: "Film 1",
-      thumbnail: "thumbnail1.jpg",
-      synopsis: "Synopsis för Film 1",
-      rating: "5",
-      genre: "Drama",
-      year: 2022,
-      actors: ["Skådespelare 1", "Skådespelare 2"],
-    },
-    {
-      title: "Film 2",
-      thumbnail: "thumbnail2.jpg",
-      synopsis: "Synopsis för Film 2",
-      rating: "4",
-      genre: "Action",
-      year: 2021,
-      actors: ["Skådespelare A", "Skådespelare B"],
-    },
-  ];  
-  
+  {
+    title: "Film 1",
+    thumbnail: "thumbnail1.jpg",
+    synopsis: "Synopsis för Film 1",
+    rating: "5",
+    genre: "Drama",
+    year: 2022,
+    actors: ["Skådespelare 1", "Skådespelare 2"],
+  },
+  {
+    title: "Film 2",
+    thumbnail: "thumbnail2.jpg",
+    synopsis: "Synopsis för Film 2",
+    rating: "4",
+    genre: "Action",
+    year: 2021,
+    actors: ["Skådespelare A", "Skådespelare B"],
+  },
+];
+
+// mockar en film för att testa borttagning och tillägg
+const mockMovie = {
+  title: "Film 1",
+  thumbnail: "thumbnail1.jpg",
+  synopsis: "Synopsis för Film 1",
+  rating: "5",
+  genre: "Drama",
+  year: 2022,
+  actors: ["Skådespelare 1", "Skådespelare 2"],
+};
 
 // Test 1: Visa meddelande när det inte finns några bokmärkta filmer
 test("visar meddelande när det inte finns några bokmärkta filmer", () => {
@@ -59,10 +70,107 @@ test("visar bokmärken när de finns", () => {
 
   render(<BookMarkedScreen />);
 
-  // kollar att båda fikmerna renderar bokmärke
+  // kollar att båda filmerna renderar bokmärke
   const movie1 = screen.getByText(/film 1/i);
   const movie2 = screen.getByText(/film 2/i);
 
   expect(movie1).toBeInTheDocument();
   expect(movie2).toBeInTheDocument();
+});
+
+
+// Test 3: testar att lägga till ett bokmärke och uppdatera localStorage
+test("lägger till ett bokmärke och uppdaterar localStorage", () => {
+  const mockAddBookmark = jest.fn((movie) => {
+    localStorage.setItem("bookmarks", JSON.stringify([movie]));
+  });
+  const mockRemoveBookmark = jest.fn();
+  const mockIsBookmarked = jest.fn().mockReturnValue(false);
+
+  // Mocka localStorage.setItem
+  const setItemSpy = jest.spyOn(Storage.prototype, "setItem");
+
+  // mockar useBookmarks
+  (useBookmarks as jest.Mock).mockReturnValue({
+    bookmarks: [],
+    addBookmark: mockAddBookmark,
+    removeBookmark: mockRemoveBookmark,
+    isBookmarked: mockIsBookmarked,
+  });
+
+  const { container, rerender } = render(<MovieCard {...mockMovie} />);
+
+  // kollar att filmen inte är bokmärkt innan vi lägger till den
+  expect(mockIsBookmarked(mockMovie.title)).toBe(false);
+
+  // hitta knappen med querySelector
+  const bookmarkButton = container.querySelector('.bookmark-button');
+  expect(bookmarkButton).toBeInTheDocument();
+
+  fireEvent.click(bookmarkButton!);
+
+  expect(mockAddBookmark).toHaveBeenCalledWith(mockMovie);
+
+  // kollar att localStorage har uppdaterats med den nya filmen
+  expect(setItemSpy).toHaveBeenCalledWith(
+    "bookmarks",
+    JSON.stringify([mockMovie])
+  );
+
+  // uppdaterar mock - simulerar att bokmärke lagts till
+  mockIsBookmarked.mockReturnValue(true);
+
+  // simulerar att listan har uppdaterats
+  rerender(<MovieCard {...mockMovie} />);
+
+  expect(mockIsBookmarked(mockMovie.title)).toBe(true);
+});
+
+
+// Test 4: testar att ta bort ett bokmärke och uppdatera localStorage
+test("tar bort ett bokmärke och uppdaterar localStorage", () => {
+  const mockAddBookmark = jest.fn();
+  const mockRemoveBookmark = jest.fn(() => {
+    localStorage.setItem("bookmarks", JSON.stringify([]));
+  });
+
+  const mockIsBookmarked = jest.fn().mockReturnValue(true);
+
+  // mockar localStorage.setItem
+  const setItemSpy = jest.spyOn(Storage.prototype, "setItem");
+
+  // mockar useBookmarks 
+  (useBookmarks as jest.Mock).mockReturnValue({
+    bookmarks: [mockMovie],
+    addBookmark: mockAddBookmark,
+    removeBookmark: mockRemoveBookmark,
+    isBookmarked: mockIsBookmarked,
+  });
+
+  const { container, rerender } = render(<MovieCard {...mockMovie} />);
+
+  // kollar att filmen är bokmärkt innan vi tar bort den
+  expect(mockIsBookmarked(mockMovie.title)).toBe(true);
+
+  // hitta knappen med querySelector
+  const bookmarkButton = container.querySelector('.bookmark-button');
+  expect(bookmarkButton).toBeInTheDocument();
+
+  fireEvent.click(bookmarkButton!);
+
+  expect(mockRemoveBookmark).toHaveBeenCalledWith(mockMovie.title);
+
+  // kollar att localStorage har uppdaterats
+  expect(setItemSpy).toHaveBeenCalledWith(
+    "bookmarks",
+    JSON.stringify([])
+  );
+
+  // uppdaterar mock 
+  mockIsBookmarked.mockReturnValue(false);
+
+  // renderar om komponenten för att simulera att listan har uppdaterats
+  rerender(<MovieCard {...mockMovie} />);
+
+  expect(mockIsBookmarked(mockMovie.title)).toBe(false);
 });


### PR DESCRIPTION
**A total of four tests for Bookmark.**
I've mocked the useBookmarks hook from the BookMarkedContext to simulate two movies being bookmarked. This could test how BookMarkedScreen renders when bookmarks are present as well as verify that interactions such as adding and removing movies work correctly.
Manually updating localStorage in the test mocks, where I simulate a movie being added or removed from bookmarks. By mocking the interaction with localStorage in the tests, I can verify that the functions to add and remove movies in BookMarkedScreen work as expected.

**Test 1:** that the "show message when there are no bookmarked movies" message appears when there are no bookmarked movies.
**Test 2:** That the two mocked movies have been added to bookmarkScreen
**Test 3:** Testing adding a bookmark and local storage being updated
**Test 4:** Testar att ta bort ett bokmärke från en film och att localstorage har uppdaterats

**4/4 passed**